### PR TITLE
Resolving the compilation failure caused by the incorrect use of the …

### DIFF
--- a/FBRetainCycleDetector.podspec
+++ b/FBRetainCycleDetector.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/facebook/FBRetainCycleDetector.git",
     :tag => "0.1.4"
   }
-  s.source_files  = "FBRetainCycleDetector", "{FBRetainCycleDetector,rcd_fishhook}/**/*.{h,m,mm,c}"
+  s.source_files  = "FBRetainCycleDetector", "{FBRetainCycleDetector,rcd_fishhook}/**/*.{h,m,mm,c,swift}"
 
   mrr_files = [
     'FBRetainCycleDetector/Associations/FBAssociationManager.h',

--- a/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
+++ b/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
@@ -15,7 +15,11 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#if __has_include("FBRetainCycleDetector-Swift.h")
+    #import "FBRetainCycleDetector-Swift.h"
+#else
+    #import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#endif
 
 #import "FBIvarReference.h"
 #import "FBObjectInStructReference.h"

--- a/FBRetainCycleDetector/Layout/Classes/Reference/FBSwiftReference.m
+++ b/FBRetainCycleDetector/Layout/Classes/Reference/FBSwiftReference.m
@@ -8,7 +8,11 @@
 
 #import "FBSwiftReference.h"
 
-#import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#if __has_include("FBRetainCycleDetector-Swift.h")
+    #import "FBRetainCycleDetector-Swift.h"
+#else
+    #import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#endif
 
 @implementation FBSwiftReference
 


### PR DESCRIPTION
…reference `#import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>`. Correcting the error in the podspec where Swift files were not included.